### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: canstralian
+patreon: canstralian
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: sadejager
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
This pull request adds a new `.github/FUNDING.yml` file to specify supported funding platforms and associated usernames for sponsorship opportunities.

Funding configuration:

* [`.github/FUNDING.yml`](diffhunk://#diff-07985fdcade0e64d11482724879a644f07879ba61b8fb6c6119e1b1902b72ae4R1-R15): Introduced a funding configuration file with entries for platforms like GitHub, Patreon, Ko-fi, and Buy Me a Coffee. Some placeholders are included for other platforms, allowing customization with specific usernames or URLs.

## Summary by Sourcery

Add GitHub FUNDING.yml to support project sponsorship platforms

New Features:
- Created a funding configuration file to enable sponsorship opportunities

Documentation:
- Added .github/FUNDING.yml with supported funding platforms